### PR TITLE
1 - Fix for scopes with new lines

### DIFF
--- a/autofilename.py
+++ b/autofilename.py
@@ -24,7 +24,7 @@ class FileNameComplete(sublime_plugin.EventListener):
 
         this_dir = os.path.split(view.file_name())[0] + os.path.sep
 
-        cur_path = view.substr(view.extract_scope(sel-1))
+        cur_path = view.substr(view.extract_scope(sel-1)).replace('\r\n', '\n').split('\n')[0]
 
         if cur_path.startswith(("'","\"")):
             cur_path = cur_path[1:-1]


### PR DESCRIPTION
Hi!

My first test with this package was to write:

```
<!DOCTYPE html>
<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
<title></title>
</head>
<body>
<img src="/
</body>
</html>
```

I typed manually `"<img src="/` and the package failed to show the complementation because `view.extract_scope` in this situation will return this:

```
"/
</body>
</html>
```

This commit fix this by removing everything from the first new line character ( if any )

I'm going to hack this package frequently to improve usage and little things

Thanks!
