### PR TITLE
allow autocomplete where pathname begins with "/" instead of "./"

### DIFF
--- a/autofilename.py
+++ b/autofilename.py
@@ -28,6 +28,8 @@ class FileNameComplete(sublime_plugin.EventListener):
 
         if cur_path.startswith(("'","\"")):
             cur_path = cur_path[1:-1]
+        if cur_path.startswith("/"):
+            cur_path = "." + cur_path
 
         this_dir = os.path.join(this_dir, cur_path)
 


### PR DESCRIPTION
not sure if this has unintended consequences, but i don't like having to put the "." in front of my paths when i am coding html src paths. maybe this kinda sorta addresses the requests for supporting absolute paths.
