### PR TITLE
Fix for Issue #11

### DIFF
--- a/autofilename.py
+++ b/autofilename.py
@@ -75,6 +75,8 @@ class FileNameComplete(sublime_plugin.EventListener):
         return False
 
     def on_selection_modified(self,view):
+        if view.get_window() == None:
+            return;
         sel = view.sel()[0]
         if sel.empty() and self.at_path_end(view):
             if view.substr(sel.a-1) == '/' or len(view.extract_scope(sel.a)) < 3:


### PR DESCRIPTION
During session restore, the callback is called a lot with views
that have no window. Ignore those. Fixes triggering of the "slow plugin"
dialog.
