### PR TITLE
Fix annoying bug in JavaScript regex literals

### DIFF
--- a/autofilename.py
+++ b/autofilename.py
@@ -122,6 +122,9 @@ class FileNameComplete(sublime_plugin.EventListener):
         valid_scopes = self.get_setting('afn_valid_scopes',view)
         sel = view.sel()[0].a
         completions = []
+        
+        if "string.regexp.js" in view.scope_name(sel):
+            return []
 
         if not any(s in view.scope_name(sel) for s in valid_scopes):
             return []


### PR DESCRIPTION
Now it doesn't block ST for erroneously working inside a JS regex (e.g. /\b[a-z]/gi )
