### PR TITLE
Updated setting for "afn_insert_dimensions" to string

### DIFF
--- a/autofilename.sublime-settings
+++ b/autofilename.sublime-settings
@@ -15,7 +15,7 @@
 	// Whether or not AutoFileName should insert the width
 	// and height dimensions after inserting an image into
 	// an image tag
-	"afn_insert_dimensions": true,
+	"afn_insert_dimensions": "true",
 
 	// If afn_insert_dimensions is true, by default, AutoFileName
 	// will insert height="" than width="". Setting this to true


### PR DESCRIPTION
I don't know about the other options, but I found that setting "afn_insert_dimensions" to the boolean false didn't work. Using a string value "false" did work.
