### PR TITLE
Add image dimension support for template languages like Slim

### DIFF
--- a/autofilename.sublime-settings
+++ b/autofilename.sublime-settings
@@ -10,13 +10,18 @@
 	// root of their site.
 	"afn_use_project_root": false,
 
-	// Override the project root. Will only work 
+	// Override the project root. Will only work
 	// if "auto_file_name_use_project_root" is true.
 	// Can be absolute or relative to the current directory.
 	"afn_proj_root": "../",
 
 	// Specify which scopes will trigger AutoFileName
 	"afn_valid_scopes":["string","css","sass","less","scss"],
+
+	// Turn on if using a template language like Slim and want to
+	// insert image dimensions.  If using a template language, you also have
+	// to add it to the valid scopes, above.
+	"afn_template_languages": false,
 
 	// BlackList specific scopes
 	"afn_blacklist_scopes":["string.regexp.js"],
@@ -35,12 +40,12 @@
 	// you can set the plugin to only activate with a keybinding.
 	// If you set this to true, add the following to your user-keybindings:
 	//
-	// { "keys": ["whatever"], "command": "afn_show_filenames", 
+	// { "keys": ["whatever"], "command": "afn_show_filenames",
 	//    "context":
 	//  [
 	//      { "key": "afn_use_keybinding", "operator": "equal", "operand": true }
 	//  ]
 	// }
 	//
-	"afn_use_keybinding": false 
+	"afn_use_keybinding": false
 }


### PR DESCRIPTION
This patch allows support for templating languages like [Slim](http://slim-lang.com/) and [Jade](http://jade-lang.com/) which don't have the angle brackets on img tags.

When using AutoFileName, this patch will allow turn templates structured like this:

```
      table
        tr
          td width='50px'
            img src="images/my-image.jpg"
```

into this:

```
      table
        tr
          td width='50px'
            img src="images/my-image.jpg" width="50" height="50"
```

Regular HTML `<img ../>` tags will still work, as some templates support them.

To enable, the template scope must be added to `afn_valid_scopes` and `afn_template_languages` must be set to true, like so:

```
...
"afn_valid_scopes":["string","css","sass","less","scss","slim"],
"afn_template_languages": true,
....
```
