### PR TITLE
Adding support for stylus by default

### DIFF
--- a/autofilename.sublime-settings
+++ b/autofilename.sublime-settings
@@ -10,7 +10,7 @@
 	"afn_proj_root": "",
 
 	// Specify which scopes will trigger AutoFileName
-	"afn_valid_scopes":["string","css","sass","less","scss"],
+	"afn_valid_scopes":["string","css","sass","less","scss","stylus"],
 
 	// Whether or not AutoFileName should insert the width
 	// and height dimensions after inserting an image into


### PR DESCRIPTION
Stylus is a first class citizen along with Sass and Less, commonly used by Node.js users

http://learnboost.github.io/stylus/
