### PR TITLE
Do not show autocomplete popup for every string when afn_use_keybinding is true

### DIFF
--- a/autofilename.py
+++ b/autofilename.py
@@ -168,6 +168,11 @@ class FileNameComplete(sublime_plugin.EventListener):
     def on_selection_modified_async(self,view):
         if not view.window():
             return
+        
+        # Do not open autocomplete automatically if keybinding mode is used
+        if not FileNameComplete.is_active and self.get_setting('afn_use_keybinding', view):
+            return
+        
         sel = view.sel()[0]
         if sel.empty() and self.at_path_end(view):
             scope_contents = view.substr(view.extract_scope(sel.a-1))


### PR DESCRIPTION
When using 'afn_use_keybinding' = true option the autocomplete popup still is opened inside any string and it is quite distracting. I have tried to fix this, though I am not sure if it  is okay to query settings value on every modification.
