### PR TITLE
fix the issue can't not work with javascript(babel)

### DIFF
--- a/autofilename.py
+++ b/autofilename.py
@@ -152,7 +152,7 @@ class FileNameComplete(sublime_plugin.EventListener):
     def at_path_end(self,view):
         sel = view.sel()[0]
         name = view.scope_name(sel.a)
-        if sel.empty() and 'string.end' in name:
+        if sel.empty() and ('string.end' in name or 'string.quoted.end.js' in name):
             return True
         if '.css' in name and view.substr(sel.a) == ')':
             return True


### PR DESCRIPTION
The scope name returns different values in different syntax.

javascript returns
source.js string.quoted.double.js punctuation.definition.string.end.js

javascript(babel) returns
source.js string.quoted.js punctuation.definition.string.quoted.end.js
