### PR TITLE
Prevent 'Drive Not Ready' on completion for removable drives.

### DIFF
--- a/autofilename.py
+++ b/autofilename.py
@@ -1,6 +1,10 @@
 import sublime
 import sublime_plugin
 import os
+import ctypes
+import platform
+import itertools
+import string
 from .getimageinfo import getImageInfo
 
 class AfnShowFilenames(sublime_plugin.TextCommand):
@@ -136,8 +140,12 @@ class FileNameComplete(sublime_plugin.EventListener):
         FileNameComplete.sep = '/'
 
     def get_drives(self):
-    # Search through valid drive names and see if they exist. (stolen from Facelessuser)
-        return [[d+":"+FileNameComplete.sep, d+":"+FileNameComplete.sep] for d in "ABCDEFGHIJKLMNOPQRSTUVWXYZ" if os.path.exists(d + ":")]
+        if 'Windows' not in platform.system():
+            return []
+        drive_bitmask = ctypes.cdll.kernel32.GetLogicalDrives()
+        drive_list = list(itertools.compress(string.ascii_uppercase,
+            map(lambda x:ord(x) - ord('0'), bin(drive_bitmask)[:1:-1])))
+        return [[d+":"+FileNameComplete.sep, d+":"+FileNameComplete.sep] for d in drive_list]
 
     def on_query_context(self, view, key, operator, operand, match_all):
         if key == "afn_insert_dimensions":


### PR DESCRIPTION
I am not a Python expert but I found some code to adapt, all credits to Adam Rosenfield : http://stackoverflow.com/a/4790310/4861714.

Fix issue #62.
This issue is due to `os.path.exists()` method called on removable drives on Windows. It shows an error message box because Windows handle the 'Drive Not Ready' error itself. Google `win32api.SetErrorMode(0)` for more information. Since `win32api` is not packaged with Sublime Text I opted for the `ctypes.cdll.kernel32.GetLogicalDrives()` solution.

I have not tested my patch on other platforms but for what I understand from code the `get_drives` method is Windows specific so it should not impact other platforms.